### PR TITLE
docs: update homepage for Waymo transition

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,7 +11,7 @@ locale                   : "en-US"
 title                    : "Junru Ren"
 title_separator          : "-"
 name                     : &name "Junru Ren"
-description              : &description "Student at MIT"
+description              : &description "AI, autonomy, simulation, and product-building."
 url                      : "https://junruren.com" # the base hostname & protocol for your site e.g. "https://mmistakes.github.io"
 baseurl                  : "" # the subpath of your site, e.g. "/blog"
 repository               : "junruren/junruren.github.io"
@@ -23,9 +23,9 @@ author:
   # Biographic information
   avatar           : "profile.jpg"
   name             : "Junru Ren 任俊儒"
-  bio              : "MIT EECS M.S. and MBA Candidate, MIT LGO '26"
-  location         : "Cambridge, MA"
-  employer         : "MIT"
+  bio              : "Recent MIT EECS S.M. + MBA graduate, LGO '26 | Incoming PM at Waymo"
+  location         : "SF Bay Area, CA"
+  employer         : "Waymo (Incoming)"
   uri              : # URL
   email            : "junru@computer.org"
 

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -8,31 +8,41 @@ redirect_from:
   - /about.html
 ---
 
-I’m a dual-degree candidate pursuing an S.M. in Electrical Engineering and **Computer Science** (EECS) and an MBA at MIT as a Leaders for Global Operations ([LGO](https://lgo.mit.edu/)) Fellow awarded $100,000 in fellowship.
+I recently graduated from MIT with an S.M. in Electrical Engineering and **Computer Science** (EECS) and an MBA. I was part of MIT's Leaders for Global Operations ([LGO](https://lgo.mit.edu/)) Class of 2026.
+
+I am interested in building AI systems that work in the real world: systems that can reason across messy environments, expose the right feedback to people, and become reliable products. Lately I have been thinking about simulation realism, world models, sensor simulation, synthetic data, and the product infrastructure needed to test autonomy before it reaches the road.
+
+Before MIT, I spent six years at [SoundHound](https://soundhound.com) building voice AI products in English and Chinese. My next chapter is at Waymo, where I will work as a Product Manager on simulation realism: making autonomous driving simulation more realistic, scalable, and useful for engineering, research, safety, and operations teams.
 
 ---
 
-I’m passionate about innovating at the intersection of **product** and **foundational AI research**.
+## Now
 
-[**Chat with me**](https://calendly.com/junruren-mit/hi) about:
+I am in a transition season: recently graduated, preparing to join Waymo, and thinking about how simulation, AI systems, and product judgment come together in autonomy.
 
-* **Human-AI Interaction**
-* **AI & ML** – especially representation learning, negotiation agents, and vision-language models
-* **Autonomy & Machine Vision** – applied to vehicles and beyond
-* **Game Theory & Multi-Agent Systems** – the focus of my current Nike Research Fellow internship
-* **Navigating MIT** – as an LGO, EECS, or MBA student
-* **Startup Ideas** – where AI meets the real world
+Lately I have been thinking about how simulated worlds become trustworthy product infrastructure: how to measure realism, where synthetic data helps or misleads, and how better tools let teams test rare, safety-critical scenarios before they happen on public roads.
+
+---
+
+**Chat with me** about:
+
+* **Autonomy, Simulation & Machine Vision** - world models, sensor simulation, synthetic data, and evaluation
+* **AI & Machine Learning** - foundation models, generative AI, representation learning, and vision-language models
+* **Human-AI Interaction** - how people understand, trust, and steer AI systems
+* **Multi-Agent Systems** - from negotiation to simulated road users and coordination
+* **Building AI Products** - requirements, roadmaps, and reliable systems across research, engineering, safety, and operations
+* **Navigating MIT** - LGO, EECS, MBA, and life between programs
+* **Career Transitions** - moving between industry engineering, research, graduate school, and product-building
 * **Some fun stuff**:
-  * **Public Transit & Trains** – subway analytics, model railroads, and more
-  * **Jazz & Classical Music** – clarinet player, curious about art + tech
-  * **Photography** – I love landscapes and cityscapes
+  * **Public Transit & Trains** - subway analytics, model railroads, and more
+  * **Jazz & Classical Music** - clarinet player, curious about art + tech
+  * **Photography** - I love landscapes and cityscapes
 
-I’m especially hoping to learn from researchers about:
-👉 **Breaking into research from an engineering background**
+I am especially interested in conversations about how simulation, evaluation, and product judgment turn AI research into systems people can trust.
 
 ---
 
-Before MIT, I spent six years at [SoundHound](https://soundhound.com) working on voice AI products, designing and developing conversational experiences in both English and Chinese. A few examples:
+At [SoundHound](https://soundhound.com), I worked on voice AI products, designing and developing conversational experiences in both English and Chinese. A few examples:
 
 * 🥪 Restaurant voice AI that answers phone or drive-thru orders 🗣️ _"I want a number 2 sandwich foot long on wheat bread with no pickles"_ ([Press Release](https://www.soundhound.com/newsroom/press-releases/soundhound-and-jersey-mikes-introduce-voice-ai-phone-ordering/))
 * 🚙 In-car voice AI assistant shipped to Citroën Versailles C5 X in China 🗣️ _"Roll up the windows and navigate to the nearest gas station"_ ([Press Release](https://www.soundhound.com/newsroom/press-releases/soundhound-delivers-mandarin-solution/))


### PR DESCRIPTION
## Summary
Updates the personal homepage for the post-MIT transition:

- Replaces MIT candidate/fellowship framing with recent MIT EECS S.M. + MBA graduate language.
- Adds a short `Now` section for the transition into Waymo.
- Reframes homepage interests around AI systems, autonomy, simulation realism, product judgment, and human trust.
- Refreshes sidebar metadata in `_config.yml` for SF Bay Area and incoming PM at Waymo.

## Test Coverage
No application code paths changed. This PR updates Jekyll copy/config only.

Tests: 0 -> 0 (+0 new)

## Pre-Landing Review
Pre-Landing Review: No issues found.

## Design Review
No CSS, layout, or component files changed. Local render smoke check passed.

## Eval Results
No prompt-related files changed. Evals skipped.

## Scope Drift
Scope Check: CLEAN

Intent: Refresh the homepage from current MIT student framing to recent graduate entering Waymo.

Delivered: Updated `_pages/about.md` and `_config.yml` only, preserving the existing AcademicPages structure.

## Plan Completion
Plan: `/Users/thomas/.gstack/projects/junruren-junruren.github.io/thomas-master-design-20260614-140430.md`

- [x] Update stale student/candidate homepage identity language.
- [x] Reduce fellowship/student emphasis.
- [x] Add a short `Now` section.
- [x] Refresh chat topics for current stage.
- [x] Keep SoundHound examples as industry/product proof.
- [x] Update `_config.yml` sidebar identity metadata.
- [x] Keep changes incremental and consistent with AcademicPages.

Note: The final copy adds a slightly more specific simulation realism thread based on the Waymo JD.

## Verification Results
- [x] `BUNDLE_PATH=/tmp/junruren-bundle arch -x86_64 bundle exec jekyll build`
- [x] Local render returned `200` at `http://127.0.0.1:4000/`.
- [x] Generated HTML contains the updated sidebar bio, Waymo copy, and simulation/autonomy topics.
- [x] `git diff --check` and `git diff --cached --check`

## Test plan
- [x] Jekyll build passes.
- [x] Homepage renders locally.
- [x] Updated copy appears in generated HTML.

Generated with OpenAI Codex.