### PR TITLE
fix: exclude CLAUDE.md from the Jekyll build

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -169,6 +169,7 @@ exclude:
   - assets/js/plugins
   - assets/js/vendor
   - CHANGELOG
+  - CLAUDE.md
   - Capfile
   - config
   - Dockerfile


### PR DESCRIPTION
## Summary

The post-merge deploy failed with:

```
Liquid Exception: Could not parse name of post "" in tag 'post_url' ... in CLAUDE.md
```

Root cause: the Pages builder includes `jekyll-optional-front-matter`, which treats every `.md` file as a page even without front matter, and Liquid does not respect Markdown code fences — so the inline `` `{% post_url %}` `` example in CLAUDE.md's writing-conventions section is parsed as a real (empty-named) tag and kills the build. CLAUDE.md had never been on `master` before #11, which is why this never surfaced.

One-line fix: add `CLAUDE.md` to the `exclude:` list. This also stops CLAUDE.md from being published as a page on the live site.

## Test plan

- [x] Verified CLAUDE.md is the only non-content markdown containing Liquid tags (`grep -rl '{%' --include='*.md'` outside `_posts`/`_pages`)
- [ ] Merge → deploy goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)