### PR TITLE
fix: route Substack sync around the Actions IP block

### DIFF
--- a/.github/workflows/substack-sync.yml
+++ b/.github/workflows/substack-sync.yml
@@ -34,9 +34,9 @@ jobs:
             curl -sS -m 60 "$1" -o /tmp/probe.out -w "HTTP %{http_code}, %{size_download} bytes\n" || true
             head -c 80 /tmp/probe.out; echo
           }
-          probe 'https://api.allorigins.win/raw?url=https%3A%2F%2Fjunruren.substack.com%2Ffeed'
-          probe 'https://corsproxy.io/?url=https%3A%2F%2Fjunruren.substack.com%2Ffeed'
-          probe 'https://api.codetabs.com/v1/proxy?quest=https://junruren.substack.com/feed'
+          probe 'https://api.rss2json.com/v1/api.json?rss_url=https%3A%2F%2Fjunruren.substack.com%2Ffeed'
+          probe 'https://r.jina.ai/https://junruren.substack.com/feed'
+          probe 'https://rsshub.app/substack/newsletter/junruren'
           probe 'https://wsrv.nl/?url=https%3A%2F%2Fsubstackcdn.com%2Fimage%2Ffetch%2F%24s_%217qf7%21%2Cw_1456%2Cc_limit%2Cf_auto%2Cq_auto%3Agood%2Cfl_progressive%3Asteep%2Fhttps%253A%252F%252Fsubstack-post-media.s3.amazonaws.com%252Fpublic%252Fimages%252F6bfd24db-7a99-42fd-aa61-90d482362a62_1280x853.jpeg'
 
       - name: Mirror new Substack posts

--- a/.github/workflows/substack-sync.yml
+++ b/.github/workflows/substack-sync.yml
@@ -26,7 +26,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Probe relay candidates (temporary)
+        continue-on-error: true
+        run: |
+          probe() {
+            echo "== $1"
+            curl -sS -m 60 "$1" -o /tmp/probe.out -w "HTTP %{http_code}, %{size_download} bytes\n" || true
+            head -c 80 /tmp/probe.out; echo
+          }
+          probe 'https://api.allorigins.win/raw?url=https%3A%2F%2Fjunruren.substack.com%2Ffeed'
+          probe 'https://corsproxy.io/?url=https%3A%2F%2Fjunruren.substack.com%2Ffeed'
+          probe 'https://api.codetabs.com/v1/proxy?quest=https://junruren.substack.com/feed'
+          probe 'https://wsrv.nl/?url=https%3A%2F%2Fsubstackcdn.com%2Fimage%2Ffetch%2F%24s_%217qf7%21%2Cw_1456%2Cc_limit%2Cf_auto%2Cq_auto%3Agood%2Cfl_progressive%3Asteep%2Fhttps%253A%252F%252Fsubstack-post-media.s3.amazonaws.com%252Fpublic%252Fimages%252F6bfd24db-7a99-42fd-aa61-90d482362a62_1280x853.jpeg'
+
       - name: Mirror new Substack posts
+        continue-on-error: true
         run: python3 scripts/substack_sync.py
 
       - name: Commit, push, and deploy if changed

--- a/.github/workflows/substack-sync.yml
+++ b/.github/workflows/substack-sync.yml
@@ -26,18 +26,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Probe Substack reachability (temporary)
-        continue-on-error: true
-        run: |
-          BROWSER_UA='Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36'
-          for target in 'https://junruren.substack.com/feed' 'https://junruren.substack.com/api/v1/archive?sort=new&limit=1'; do
-            echo "== $target"
-            echo "curl default UA: $(curl -sS -o /dev/null -w '%{http_code}' "$target" || true)"
-            echo "curl browser UA: $(curl -sS -o /dev/null -w '%{http_code}' -A "$BROWSER_UA" "$target" || true)"
-          done
-
       - name: Mirror new Substack posts
-        continue-on-error: true
         run: python3 scripts/substack_sync.py
 
       - name: Commit, push, and deploy if changed

--- a/.github/workflows/substack-sync.yml
+++ b/.github/workflows/substack-sync.yml
@@ -26,7 +26,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Probe Substack reachability (temporary)
+        continue-on-error: true
+        run: |
+          BROWSER_UA='Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36'
+          for target in 'https://junruren.substack.com/feed' 'https://junruren.substack.com/api/v1/archive?sort=new&limit=1'; do
+            echo "== $target"
+            echo "curl default UA: $(curl -sS -o /dev/null -w '%{http_code}' "$target" || true)"
+            echo "curl browser UA: $(curl -sS -o /dev/null -w '%{http_code}' -A "$BROWSER_UA" "$target" || true)"
+          done
+
       - name: Mirror new Substack posts
+        continue-on-error: true
         run: python3 scripts/substack_sync.py
 
       - name: Commit, push, and deploy if changed

--- a/.github/workflows/substack-sync.yml
+++ b/.github/workflows/substack-sync.yml
@@ -26,21 +26,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Probe relay candidates (temporary)
-        continue-on-error: true
-        run: |
-          probe() {
-            echo "== $1"
-            curl -sS -m 60 "$1" -o /tmp/probe.out -w "HTTP %{http_code}, %{size_download} bytes\n" || true
-            head -c 80 /tmp/probe.out; echo
-          }
-          probe 'https://api.rss2json.com/v1/api.json?rss_url=https%3A%2F%2Fjunruren.substack.com%2Ffeed'
-          probe 'https://r.jina.ai/https://junruren.substack.com/feed'
-          probe 'https://rsshub.app/substack/newsletter/junruren'
-          probe 'https://wsrv.nl/?url=https%3A%2F%2Fsubstackcdn.com%2Fimage%2Ffetch%2F%24s_%217qf7%21%2Cw_1456%2Cc_limit%2Cf_auto%2Cq_auto%3Agood%2Cfl_progressive%3Asteep%2Fhttps%253A%252F%252Fsubstack-post-media.s3.amazonaws.com%252Fpublic%252Fimages%252F6bfd24db-7a99-42fd-aa61-90d482362a62_1280x853.jpeg'
-
       - name: Mirror new Substack posts
-        continue-on-error: true
         run: python3 scripts/substack_sync.py
 
       - name: Commit, push, and deploy if changed

--- a/scripts/substack_sync.py
+++ b/scripts/substack_sync.py
@@ -18,6 +18,7 @@ Stdlib only — no pip installs needed in CI.
 from __future__ import annotations
 
 import argparse
+import datetime
 import email.utils
 import html
 import json
@@ -42,13 +43,17 @@ REQUEST_HEADERS = {
     "Accept-Language": "en-US,en;q=0.9",
 }
 # Substack (and substackcdn) block requests from GitHub Actions egress IPs at
-# the network level — every client gets an instant 403, verified empirically.
-# When a direct fetch is refused, retry through a public relay that fetches
-# server-side from unblocked IPs: allorigins for the XML feed, wsrv.nl for
-# images (allorigins times out on large binaries; wsrv.nl is a dedicated
-# image proxy). Direct is always tried first, so nothing changes where
-# Substack is reachable.
-FEED_RELAY = "https://api.allorigins.win/raw?url={}"
+# the network level — every client gets an instant 403, verified empirically
+# (urllib, curl, browser UA, API endpoints; generic proxies like allorigins
+# are blocked by Substack too). Working fallbacks, probed from a runner:
+# rss2json (a feed-reader service whose fetchers Substack allows; returns the
+# feed as JSON) and wsrv.nl (a dedicated image proxy) for substackcdn images.
+# Direct routes are always tried first, so nothing changes where Substack is
+# reachable.
+FEED_FALLBACK_URL = (
+    "https://api.rss2json.com/v1/api.json?rss_url="
+    + urllib.parse.quote(FEED_URL, safe="")
+)
 IMAGE_RELAY = "https://wsrv.nl/?url={}"
 RETRIES = 3
 
@@ -161,37 +166,61 @@ def build_post(item: dict, dry_run: bool) -> pathlib.Path:
     return path
 
 
+def parse_feed_xml(data: bytes) -> list[dict]:
+    root = ET.fromstring(data)
+    return [
+        {
+            "title": (element.findtext("title") or "").strip(),
+            "link": (element.findtext("link") or "").strip(),
+            "content": element.findtext(CONTENT_NS) or "",
+            "date": email.utils.parsedate_to_datetime(element.findtext("pubDate")),
+        }
+        for element in root.findall("./channel/item")
+    ]
+
+
+def parse_feed_rss2json(data: bytes) -> list[dict]:
+    payload = json.loads(data)
+    if payload.get("status") != "ok":
+        raise RuntimeError(f"rss2json status: {payload.get('status')!r}")
+    return [
+        {
+            "title": (entry.get("title") or "").strip(),
+            "link": (entry.get("link") or "").strip(),
+            "content": entry.get("content") or entry.get("description") or "",
+            "date": datetime.datetime.strptime(entry["pubDate"], "%Y-%m-%d %H:%M:%S"),
+        }
+        for entry in payload.get("items", [])
+    ]
+
+
+def load_feed_items() -> list[dict]:
+    try:
+        return parse_feed_xml(fetch(FEED_URL))
+    except Exception as err:  # blocked or truncated — use the feed-reader relay
+        print(f"direct feed fetch failed ({err}); falling back to rss2json")
+        return parse_feed_rss2json(fetch(FEED_FALLBACK_URL))
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--dry-run", action="store_true", help="report only; write nothing")
     args = parser.parse_args()
 
-    root = ET.fromstring(fetch(FEED_URL, FEED_RELAY))
-    items = root.findall("./channel/item")
+    items = load_feed_items()
     print(f"feed: {len(items)} item(s)")
 
     created = 0
-    for element in items:
-        title = (element.findtext("title") or "").strip()
-        link = (element.findtext("link") or "").strip()
-        content = element.findtext(CONTENT_NS) or ""
-        pub_date = email.utils.parsedate_to_datetime(element.findtext("pubDate"))
-        slug = slug_from_link(link)
+    for item in items:
+        item["slug"] = slug_from_link(item["link"])
 
-        if SITE_ORIGIN_MARKER in content:
-            print(f"skip (site-origin): {slug}")
+        if SITE_ORIGIN_MARKER in item["content"]:
+            print(f"skip (site-origin): {item['slug']}")
             continue
-        if already_mirrored(link, slug):
-            print(f"skip (already mirrored): {slug}")
+        if already_mirrored(item["link"], item["slug"]):
+            print(f"skip (already mirrored): {item['slug']}")
             continue
 
-        item = {
-            "title": title,
-            "link": link,
-            "content": content,
-            "date": pub_date,
-            "slug": slug,
-        }
         path = build_post(item, args.dry_run)
         created += 1
         prefix = "would create" if args.dry_run else "created"

--- a/scripts/substack_sync.py
+++ b/scripts/substack_sync.py
@@ -15,6 +15,8 @@ Runs from the repo root (locally or in .github/workflows/substack-sync.yml):
 Stdlib only — no pip installs needed in CI.
 """
 
+from __future__ import annotations
+
 import argparse
 import email.utils
 import html
@@ -31,8 +33,6 @@ import xml.etree.ElementTree as ET
 FEED_URL = "https://junruren.substack.com/feed"
 SITE_ORIGIN_MARKER = "Originally published at https://junruren.com"
 CONTENT_NS = "{http://purl.org/rss/1.0/modules/content/}encoded"
-# Substack sits behind Cloudflare, which 403s bot-looking User-Agents from
-# datacenter IPs (like GitHub Actions runners) — send ordinary browser headers.
 REQUEST_HEADERS = {
     "User-Agent": (
         "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
@@ -41,6 +41,15 @@ REQUEST_HEADERS = {
     "Accept": "*/*",
     "Accept-Language": "en-US,en;q=0.9",
 }
+# Substack (and substackcdn) block requests from GitHub Actions egress IPs at
+# the network level — every client gets an instant 403, verified empirically.
+# When a direct fetch is refused, retry through a public relay that fetches
+# server-side from unblocked IPs: allorigins for the XML feed, wsrv.nl for
+# images (allorigins times out on large binaries; wsrv.nl is a dedicated
+# image proxy). Direct is always tried first, so nothing changes where
+# Substack is reachable.
+FEED_RELAY = "https://api.allorigins.win/raw?url={}"
+IMAGE_RELAY = "https://wsrv.nl/?url={}"
 RETRIES = 3
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
@@ -50,20 +59,31 @@ IMAGES_ROOT = REPO_ROOT / "images" / "substack"
 IMG_EXT_RE = re.compile(r"\.(png|jpe?g|gif|webp|avif)(?=$|[?%])", re.IGNORECASE)
 
 
-def fetch(url: str) -> bytes:
-    req = urllib.request.Request(url, headers=REQUEST_HEADERS)
-    for attempt in range(1, RETRIES + 1):
-        try:
-            with urllib.request.urlopen(req, timeout=60) as resp:
-                return resp.read()
-        except urllib.error.HTTPError as err:
-            if attempt == RETRIES or err.code not in (403, 429, 500, 502, 503):
-                raise
-            delay = 10 * attempt
-            print(f"HTTP {err.code} for {url}, retrying in {delay}s "
-                  f"({attempt}/{RETRIES})")
-            time.sleep(delay)
-    raise RuntimeError("unreachable")
+def fetch(url: str, relay: str | None = None) -> bytes:
+    """GET url, falling back to the relay when the direct route is blocked."""
+    candidates = [url]
+    if relay:
+        candidates.append(relay.format(urllib.parse.quote(url, safe="")))
+    last_error: Exception = RuntimeError("no fetch candidates")
+    for candidate in candidates:
+        req = urllib.request.Request(candidate, headers=REQUEST_HEADERS)
+        for attempt in range(1, RETRIES + 1):
+            try:
+                with urllib.request.urlopen(req, timeout=60) as resp:
+                    return resp.read()
+            except (urllib.error.HTTPError, urllib.error.URLError) as err:
+                last_error = err
+                code = getattr(err, "code", None)
+                if code == 403:
+                    print(f"HTTP 403 for {candidate}, trying next route")
+                    break  # hard block — retrying the same route is pointless
+                if attempt == RETRIES:
+                    break
+                delay = 5 * attempt
+                print(f"{err} for {candidate}, retrying in {delay}s "
+                      f"({attempt}/{RETRIES})")
+                time.sleep(delay)
+    raise last_error
 
 
 def slug_from_link(link: str) -> str:
@@ -98,7 +118,7 @@ def localize_images(content: str, slug: str, dry_run: bool) -> str:
             continue
         target = REPO_ROOT / local_rel.lstrip("/")
         target.parent.mkdir(parents=True, exist_ok=True)
-        target.write_bytes(fetch(url))
+        target.write_bytes(fetch(url, IMAGE_RELAY))
     for url, local_rel in seen.items():
         content = content.replace(f'src="{url}"', f'src="{local_rel}"')
         content = content.replace(f'href="{url}"', f'href="{local_rel}"')
@@ -146,7 +166,7 @@ def main() -> int:
     parser.add_argument("--dry-run", action="store_true", help="report only; write nothing")
     args = parser.parse_args()
 
-    root = ET.fromstring(fetch(FEED_URL))
+    root = ET.fromstring(fetch(FEED_URL, FEED_RELAY))
     items = root.findall("./channel/item")
     print(f"feed: {len(items)} item(s)")
 

--- a/scripts/substack_sync.py
+++ b/scripts/substack_sync.py
@@ -22,6 +22,8 @@ import json
 import pathlib
 import re
 import sys
+import time
+import urllib.error
 import urllib.parse
 import urllib.request
 import xml.etree.ElementTree as ET
@@ -29,7 +31,17 @@ import xml.etree.ElementTree as ET
 FEED_URL = "https://junruren.substack.com/feed"
 SITE_ORIGIN_MARKER = "Originally published at https://junruren.com"
 CONTENT_NS = "{http://purl.org/rss/1.0/modules/content/}encoded"
-USER_AGENT = "Mozilla/5.0 (compatible; junruren.com archive sync)"
+# Substack sits behind Cloudflare, which 403s bot-looking User-Agents from
+# datacenter IPs (like GitHub Actions runners) — send ordinary browser headers.
+REQUEST_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36"
+    ),
+    "Accept": "*/*",
+    "Accept-Language": "en-US,en;q=0.9",
+}
+RETRIES = 3
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 POSTS_DIR = REPO_ROOT / "_posts"
@@ -39,9 +51,19 @@ IMG_EXT_RE = re.compile(r"\.(png|jpe?g|gif|webp|avif)(?=$|[?%])", re.IGNORECASE)
 
 
 def fetch(url: str) -> bytes:
-    req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
-    with urllib.request.urlopen(req, timeout=60) as resp:
-        return resp.read()
+    req = urllib.request.Request(url, headers=REQUEST_HEADERS)
+    for attempt in range(1, RETRIES + 1):
+        try:
+            with urllib.request.urlopen(req, timeout=60) as resp:
+                return resp.read()
+        except urllib.error.HTTPError as err:
+            if attempt == RETRIES or err.code not in (403, 429, 500, 502, 503):
+                raise
+            delay = 10 * attempt
+            print(f"HTTP {err.code} for {url}, retrying in {delay}s "
+                  f"({attempt}/{RETRIES})")
+            time.sleep(delay)
+    raise RuntimeError("unreachable")
 
 
 def slug_from_link(link: str) -> str:


### PR DESCRIPTION
## Summary

The scheduled Substack sync failed with `HTTP 403` — **Substack blocks GitHub Actions egress IPs at the network level**. Empirical probes from a runner showed:

| Route | Result |
|---|---|
| Direct (urllib / curl / browser UA / API endpoints) | 403 instantly |
| Generic proxies (allorigins, codetabs) | 522 — Substack blocks them too |
| corsproxy.io | paid plan required |
| **rss2json** (feed-reader service, JSON representation) | **200, complete feed, full content** |
| **wsrv.nl** (image proxy) for substackcdn | **200, intact JPEG** |

The sync now tries the direct XML feed first (unchanged behavior wherever Substack is reachable) and falls back to rss2json's JSON representation of the same feed; image downloads fall back through wsrv.nl. Plus retry/backoff and browser-like headers on all fetches.

## Test plan

- [x] Local dry-run, direct XML path: 5 items, all skipped as site-origin
- [x] Local test of rss2json parse path: 5 items, markers detected, dates parsed
- [x] **Dispatched from this branch on a real runner: [run 31463400311](https://github.com/junruren/junruren.github.io/actions/runs/31463400311) — green.** Log shows `direct feed fetch failed (403); falling back to rss2json` → `feed: 5 item(s)` → 5 × skip → `No new posts.`

Suggest **squash-merge** (branch contains temporary probe commits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)